### PR TITLE
Upgrade bcprov-jdk15on to version 1.66

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.bouncycastle:bcprov-jdk15on:1.55'
+    implementation 'org.bouncycastle:bcprov-jdk15on:1.66'
 }
 
 test {


### PR DESCRIPTION
![large-logo-191x34](https://user-images.githubusercontent.com/33268211/98482806-aa4ffd00-21b8-11eb-8a44-82947e3acf9a.png)<p>Upgrades bcprov-jdk15on to 1.66 to fix vulnerabilities in current version